### PR TITLE
Add Android version of cocktail app

### DIFF
--- a/AndroidApp/app/build.gradle.kts
+++ b/AndroidApp/app/build.gradle.kts
@@ -1,0 +1,63 @@
+plugins {
+    id("com.android.application")
+    kotlin("android")
+}
+
+android {
+    namespace = "com.example.cocktails"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.example.cocktails"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    buildFeatures {
+        compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.1"
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.10.1")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.2")
+    implementation("androidx.activity:activity-compose:1.7.2")
+    implementation("androidx.compose.ui:ui:1.5.0")
+    implementation("androidx.compose.material3:material3:1.1.0")
+    implementation("androidx.compose.ui:ui-tooling-preview:1.5.0")
+    implementation("androidx.navigation:navigation-compose:2.7.0")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.6.2")
+    implementation("com.squareup.retrofit2:retrofit:2.9.0")
+    implementation("com.squareup.retrofit2:converter-moshi:2.9.0")
+    implementation("com.squareup.moshi:moshi-kotlin:1.15.0")
+    implementation("com.squareup.okhttp3:logging-interceptor:5.0.0-alpha.11")
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.5.0")
+    debugImplementation("androidx.compose.ui:ui-tooling:1.5.0")
+}

--- a/AndroidApp/app/proguard-rules.pro
+++ b/AndroidApp/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# ProGuard rules for release builds

--- a/AndroidApp/app/src/main/AndroidManifest.xml
+++ b/AndroidApp/app/src/main/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.cocktails">
+
+    <application
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.Cocktails">
+        <activity android:name=".ui.MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/AndroidApp/app/src/main/java/com/example/cocktails/data/CocktailRepository.kt
+++ b/AndroidApp/app/src/main/java/com/example/cocktails/data/CocktailRepository.kt
@@ -1,0 +1,19 @@
+package com.example.cocktails.data
+
+import com.example.cocktails.network.NetworkModule
+
+class CocktailRepository {
+    private val api = NetworkModule.api
+
+    suspend fun fetchDailyCocktails(): List<Drink> {
+        return api.searchCocktails("margarita").drinks
+    }
+
+    suspend fun search(query: String): List<Drink> {
+        return api.searchCocktails(query).drinks
+    }
+
+    suspend fun fetchByLetter(letter: String): List<Drink> {
+        return api.fetchCocktails(letter).drinks
+    }
+}

--- a/AndroidApp/app/src/main/java/com/example/cocktails/data/Models.kt
+++ b/AndroidApp/app/src/main/java/com/example/cocktails/data/Models.kt
@@ -1,0 +1,20 @@
+package com.example.cocktails.data
+
+import com.squareup.moshi.Json
+
+data class Results(
+    @Json(name = "drinks") val drinks: List<Drink>
+)
+
+data class Drink(
+    @Json(name = "idDrink") val id: String,
+    @Json(name = "strDrink") val name: String,
+    @Json(name = "strDrinkThumb") val thumbnail: String,
+    @Json(name = "strAlcoholic") val alcoholic: String,
+    @Json(name = "strInstructions") val instructions: String,
+    @Json(name = "strIngredient1") val ingredient1: String?,
+    @Json(name = "strIngredient2") val ingredient2: String?,
+    @Json(name = "strIngredient3") val ingredient3: String?,
+    @Json(name = "strIngredient4") val ingredient4: String?,
+    @Json(name = "strIngredient5") val ingredient5: String?
+)

--- a/AndroidApp/app/src/main/java/com/example/cocktails/network/CocktailApi.kt
+++ b/AndroidApp/app/src/main/java/com/example/cocktails/network/CocktailApi.kt
@@ -1,0 +1,13 @@
+package com.example.cocktails.network
+
+import com.example.cocktails.data.Results
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface CocktailApi {
+    @GET("search.php")
+    suspend fun searchCocktails(@Query("s") query: String): Results
+
+    @GET("search.php")
+    suspend fun fetchCocktails(@Query("f") firstLetter: String): Results
+}

--- a/AndroidApp/app/src/main/java/com/example/cocktails/network/NetworkModule.kt
+++ b/AndroidApp/app/src/main/java/com/example/cocktails/network/NetworkModule.kt
@@ -1,0 +1,30 @@
+package com.example.cocktails.network
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+
+object NetworkModule {
+    private const val BASE_URL = "https://www.thecocktaildb.com/api/json/v1/1/"
+
+    private val moshi = Moshi.Builder()
+        .add(KotlinJsonAdapterFactory())
+        .build()
+
+    private val client = OkHttpClient.Builder()
+        .addInterceptor(HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BASIC
+        })
+        .build()
+
+    private val retrofit = Retrofit.Builder()
+        .baseUrl(BASE_URL)
+        .client(client)
+        .addConverterFactory(MoshiConverterFactory.create(moshi))
+        .build()
+
+    val api: CocktailApi = retrofit.create(CocktailApi::class.java)
+}

--- a/AndroidApp/app/src/main/java/com/example/cocktails/ui/HomeViewModel.kt
+++ b/AndroidApp/app/src/main/java/com/example/cocktails/ui/HomeViewModel.kt
@@ -1,0 +1,25 @@
+package com.example.cocktails.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.cocktails.data.CocktailRepository
+import com.example.cocktails.data.Drink
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class HomeViewModel(private val repository: CocktailRepository = CocktailRepository()) : ViewModel() {
+    private val _cocktails = MutableStateFlow<List<Drink>>(emptyList())
+    val cocktails: StateFlow<List<Drink>> = _cocktails.asStateFlow()
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        viewModelScope.launch {
+            _cocktails.value = repository.fetchDailyCocktails()
+        }
+    }
+}

--- a/AndroidApp/app/src/main/java/com/example/cocktails/ui/MainActivity.kt
+++ b/AndroidApp/app/src/main/java/com/example/cocktails/ui/MainActivity.kt
@@ -1,0 +1,129 @@
+package com.example.cocktails.ui
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import com.example.cocktails.ui.theme.CocktailsTheme
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            CocktailsTheme {
+                Surface(color = MaterialTheme.colorScheme.background) {
+                    MainScreen()
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun MainScreen() {
+    val navController = rememberNavController()
+    val items = listOf("home", "search", "shop")
+    Scaffold(
+        bottomBar = {
+            BottomNavigationBar(navController, items)
+        }
+    ) { inner ->
+        NavHost(navController, startDestination = "home", modifier = Modifier.padding(inner)) {
+            composable("home") {
+                val vm: HomeViewModel = viewModel()
+                HomeScreen(vm)
+            }
+            composable("search") {
+                val vm: SearchViewModel = viewModel()
+                SearchScreen(vm)
+            }
+            composable("shop") { PlaceholderScreen("Shop") }
+        }
+    }
+}
+
+@Composable
+fun BottomNavigationBar(navController: androidx.navigation.NavHostController, items: List<String>) {
+    androidx.compose.material3.NavigationBar {
+        val navBackStackEntry by navController.currentBackStackEntryAsState()
+        val current = navBackStackEntry?.destination?.route
+        items.forEach { screen ->
+            androidx.compose.material3.NavigationBarItem(
+                selected = current == screen,
+                onClick = {
+                    navController.navigate(screen) {
+                        popUpTo(navController.graph.findStartDestination().id) { saveState = true }
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                },
+                label = { Text(screen.capitalize()) },
+                icon = { }
+            )
+        }
+    }
+}
+
+@Composable
+fun HomeScreen(viewModel: HomeViewModel) {
+    val items by viewModel.cocktails.collectAsState()
+    androidx.compose.foundation.lazy.LazyColumn {
+        items(items) { drink ->
+            androidx.compose.material3.Text(drink.name)
+        }
+    }
+}
+
+@Composable
+fun SearchScreen(viewModel: SearchViewModel) {
+    var query by remember { mutableStateOf("") }
+    val results by viewModel.results.collectAsState()
+
+    androidx.compose.foundation.layout.Column {
+        androidx.compose.material3.OutlinedTextField(
+            value = query,
+            onValueChange = {
+                query = it
+                viewModel.search(it)
+            },
+            label = { androidx.compose.material3.Text("Search") }
+        )
+        androidx.compose.foundation.lazy.LazyColumn {
+            items(results) { drink ->
+                androidx.compose.material3.Text(drink.name)
+            }
+        }
+    }
+}
+
+@Composable
+fun PlaceholderScreen(text: String) {
+    androidx.compose.material3.Text(text)
+}
+
+@Preview(showBackground = true)
+@Composable
+fun DefaultPreview() {
+    CocktailsTheme {
+        MainScreen()
+    }
+}

--- a/AndroidApp/app/src/main/java/com/example/cocktails/ui/SearchViewModel.kt
+++ b/AndroidApp/app/src/main/java/com/example/cocktails/ui/SearchViewModel.kt
@@ -1,0 +1,21 @@
+package com.example.cocktails.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.cocktails.data.CocktailRepository
+import com.example.cocktails.data.Drink
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class SearchViewModel(private val repository: CocktailRepository = CocktailRepository()) : ViewModel() {
+    private val _results = MutableStateFlow<List<Drink>>(emptyList())
+    val results: StateFlow<List<Drink>> = _results.asStateFlow()
+
+    fun search(query: String) {
+        viewModelScope.launch {
+            _results.value = if (query.isNotBlank()) repository.search(query) else emptyList()
+        }
+    }
+}

--- a/AndroidApp/app/src/main/java/com/example/cocktails/ui/theme/Theme.kt
+++ b/AndroidApp/app/src/main/java/com/example/cocktails/ui/theme/Theme.kt
@@ -1,0 +1,21 @@
+package com.example.cocktails.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+
+private val DarkColors = darkColorScheme()
+private val LightColors = lightColorScheme()
+
+@Composable
+fun CocktailsTheme(
+    darkTheme: Boolean = false,
+    content: @Composable () -> Unit
+) {
+    val colors = if (darkTheme) DarkColors else LightColors
+    MaterialTheme(
+        colorScheme = colors,
+        content = content
+    )
+}

--- a/AndroidApp/app/src/main/res/values/colors.xml
+++ b/AndroidApp/app/src/main/res/values/colors.xml
@@ -1,0 +1,6 @@
+<resources>
+    <color name="purple_200">#BB86FC</color>
+    <color name="purple_500">#6200EE</color>
+    <color name="purple_700">#3700B3</color>
+    <color name="teal_200">#03DAC5</color>
+</resources>

--- a/AndroidApp/app/src/main/res/values/strings.xml
+++ b/AndroidApp/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Cocktails</string>
+</resources>

--- a/AndroidApp/app/src/main/res/values/themes.xml
+++ b/AndroidApp/app/src/main/res/values/themes.xml
@@ -1,0 +1,5 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.Cocktails" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:statusBarColor" tools:targetApi="31">?attr/colorPrimary</item>
+    </style>
+</resources>

--- a/AndroidApp/build.gradle.kts
+++ b/AndroidApp/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "8.1.0" apply false
+    kotlin("android") version "1.9.0" apply false
+}

--- a/AndroidApp/gradle.properties
+++ b/AndroidApp/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx2048m
+android.useAndroidX=true
+kotlin.code.style=official

--- a/AndroidApp/settings.gradle.kts
+++ b/AndroidApp/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "Cocktails"
+include(":app")


### PR DESCRIPTION
## Summary
- create Android project using Kotlin and Jetpack Compose
- add Retrofit networking stack and repository pattern
- implement Compose-based main activity with navigation and screens

## Testing
- `gradle -p AndroidApp tasks --console=plain` *(fails: could not resolve plugin due to missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_685c5e282dbc833183cad0abc8b70568