### PR TITLE
Add Gradle wrapper config without bundled jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+AndroidApp/gradle/wrapper/gradle-wrapper.jar
+
+# Ignore gradle wrapper jar
+**/gradle-wrapper.jar

--- a/AndroidApp/build.gradle.kts
+++ b/AndroidApp/build.gradle.kts
@@ -1,4 +1,4 @@
 plugins {
-    id("com.android.application") version "8.1.0" apply false
-    kotlin("android") version "1.9.0" apply false
+    id("com.android.application") version "8.4.0" apply false
+    kotlin("android") version "1.9.23" apply false
 }

--- a/AndroidApp/gradle/wrapper/gradle-wrapper.properties
+++ b/AndroidApp/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip

--- a/AndroidApp/gradlew
+++ b/AndroidApp/gradlew
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+DIR="$(cd "$(dirname "$0")" && pwd)"
+exec java -cp "$DIR/gradle/wrapper/gradle-wrapper.jar" org.gradle.wrapper.GradleWrapperMain "$@"

--- a/AndroidApp/gradlew.bat
+++ b/AndroidApp/gradlew.bat
@@ -1,0 +1,5 @@
+@echo off
+set DIR=%~dp0
+set CMD="%JAVA_HOME%\bin\java"
+if not exist %CMD% set CMD=java
+%CMD% -cp "%DIR%\gradle\wrapper\gradle-wrapper.jar" org.gradle.wrapper.GradleWrapperMain %*


### PR DESCRIPTION
## Summary
- specify Android and Kotlin plugin versions in the Gradle build
- configure Gradle wrapper to download Gradle 8.4
- remove the binary `gradle-wrapper.jar` and ignore it in git

## Testing
- `gradle --version`
- `gradle assembleDebug` *(fails: plugin artifact not found due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685c6314e5548331a057003b708398f0